### PR TITLE
Replace old MaxMind plugin with the new GeoIP one

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -9,14 +9,13 @@
     "type": "data_in"
   },
   {
-    "name": "MaxMind GeoIP",
-    "url": "https://www.npmjs.com/package/@posthog/maxmind-plugin",
-    "description": "Enrich your collected events with GeoIP data from MaxMind",
+    "name": "GeoIP",
+    "url": "https://github.com/PostHog/posthog-plugin-geoip",
+    "description": "Enrich PostHog events and persons with IP location data.",
     "verified": true,
     "maintainer": "official",
     "displayOnWebsiteLib": true,
-    "type": "data_in",
-    "imageLink": "https://raw.githubusercontent.com/PostHog/posthog-maxmind-plugin/main/logo.png"
+    "type": "data_in"
   },
   {
     "name": "Hello World",


### PR DESCRIPTION
Preparation for the official launch of the new IP location plugin.

Unfortunately there is a problem here: the new plugin requires PostHog 1.24+… which hasn't been released yet. **So we can't really do this yet.**

Another issue is that older PostHog versions will also see this plugin with no outright notice that it's not compatible, which is not ideal UX. Time to settle on a https://github.com/PostHog/plugin-server/issues/12 approach @mariusandra?