### PR TITLE
Update the Hello World plugin

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -19,10 +19,10 @@
   },
   {
     "name": "Hello World",
-    "url": "https://github.com/PostHog/helloworldplugin",
-    "description": "Greet the World and Foo a Bar",
+    "url": "https://github.com/PostHog/posthog-hello-world-plugin",
+    "description": "Greet the world with every PostHog event",
     "verified": true,
-    "maintainer": "community",
+    "maintainer": "official",
     "displayOnWebsiteLib": false,
     "type": "data_in"
   },

--- a/repository.json
+++ b/repository.json
@@ -20,7 +20,7 @@
   {
     "name": "Hello World",
     "url": "https://github.com/PostHog/posthog-hello-world-plugin",
-    "description": "Greet the world with every PostHog event",
+    "description": "Greet the world with every PostHog event. An example plugin.",
     "verified": true,
     "maintainer": "official",
     "displayOnWebsiteLib": false,


### PR DESCRIPTION
The Hello World plugin has been reworked for modernity (https://github.com/PostHog/posthog-hello-world-plugin/pull/4), and also renamed from weird `helloworldplugin` to `posthog-hello-world-plugin`, as suggested in our docs.