### PR TITLE
Add auto cohorts plugin to repo

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -253,5 +253,14 @@
     "maintainer": "official",
     "displayOnWebsiteLib": true,
     "type": "data_out"
-  }
+  },
+  {
+    "name": "Automatic Cohort Creator",
+    "url": "https://github.com/PostHog/posthog-automatic-cohorts-plugin",
+    "description": "Automatic cohort creation based on user properties.",
+    "verified": true,
+    "maintainer": "official",
+    "displayOnWebsiteLib": true,
+    "type": "data_in"
+   }
 ]


### PR DESCRIPTION
Demo failed because I had a cache preventing duplicate cohort creation 🤦 

Plugin code: https://github.com/PostHog/posthog-automatic-cohorts-plugin/blob/main/index.ts

https://user-images.githubusercontent.com/38760734/123673990-7abd3600-d817-11eb-8779-e5248a631188.mov

Worth noting this is subject to the same issues as the PagerDuty, GitHub, GitLab, and Bitbucket plugins. See https://github.com/PostHog/posthog/issues/4849

Tagging you @timgl in case you want to further a discussion on groups off the back of this.