### PR TITLE
Adding in Event Filter plugin

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -343,5 +343,15 @@
     "maintainer": "official",
     "displayOnWebsiteLib": true,
     "type": "data_in"
+  },
+  {
+    "name": "Event Filter",
+    "url": "https://github.com/GoPreki/posthog-event-filter-plugin",
+    "description": "Stop storing specified events",
+    "verified": true,
+    "maintainer": "community",
+    "displayOnWebsiteLib": true,
+    "type": "data_in",
+    "imageLink": "https://raw.githubusercontent.com/GoPreki/posthog-event-filter-plugin/main/icon.png"
   }
 ]


### PR DESCRIPTION
Add a plugin to be able to filter events based on their name.

We have a particular case, we want to keep using autocapture events (to get pageleave and pageview events) but we don't want the usual $autocapture (clicks, interactions, etc), so we can't just turn off autocapture from the app config.